### PR TITLE
make GetRandom use a thread-safe generator

### DIFF
--- a/Source/FizzWare.NBuilder/Generators/GetRandom.cs
+++ b/Source/FizzWare.NBuilder/Generators/GetRandom.cs
@@ -6,7 +6,21 @@ namespace FizzWare.NBuilder.Generators
 {
     public class GetRandom
     {
-        private static readonly IRandomGenerator generator = new RandomGenerator();        
+        [ThreadStatic]
+        private static IRandomGenerator __threadSafeGenerator;
+
+        private static IRandomGenerator generator
+        {
+            get
+            {
+                if (__threadSafeGenerator == null)
+                {
+                    __threadSafeGenerator = new RandomGenerator();
+                }
+
+                return __threadSafeGenerator;
+            }
+        }
         
         private static DateTime minSqlServerDate = new DateTime(1753, 1, 1);
         private static DateTime maxSqlServerDate = new DateTime(9999, 12, 31);


### PR DESCRIPTION
This resolves #29 by making the underlying IRandomGenerator in GetRandom unique per thread. The initialization can't be done in the declaration because ["such initialization occurs only once, when the class constructor executes, and therefore affects only one thread"](https://msdn.microsoft.com/en-us/library/system.threadstaticattribute.aspx).

 Another alternative would be to use a lock when accessing the IRandomGenerator.

Even though it's a minor change, I wasn't able to get the solution to load...so it's probably worth double checking that this works.